### PR TITLE
Permito setear properties programáticamente

### DIFF
--- a/src/main/java/org/uqbarproject/jpa/java8/extras/PerThreadEntityManagers.java
+++ b/src/main/java/org/uqbarproject/jpa/java8/extras/PerThreadEntityManagers.java
@@ -16,7 +16,8 @@ public class PerThreadEntityManagers {
 
    static {
       try {
-         emf = Persistence.createEntityManagerFactory("db");
+         emf = Persistence.createEntityManagerFactory("db",
+             PersistenceUnitProperties.INSTANCE.lock().getProperties());
          threadLocal = new ThreadLocal<>();
       } catch (Exception e) {
          e.printStackTrace();

--- a/src/main/java/org/uqbarproject/jpa/java8/extras/PersistenceUnitProperties.java
+++ b/src/main/java/org/uqbarproject/jpa/java8/extras/PersistenceUnitProperties.java
@@ -1,0 +1,52 @@
+package org.uqbarproject.jpa.java8.extras;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @author RaniAgus
+ */
+public class PersistenceUnitProperties {
+   public static final PersistenceUnitProperties INSTANCE = new PersistenceUnitProperties();
+
+   private final Properties properties = new Properties();
+   private boolean locked = false;
+
+   private PersistenceUnitProperties() {
+   }
+
+   public PersistenceUnitProperties loadFile(String path) throws Exception {
+      ensureUnlocked();
+      properties.load(Files.newInputStream(Paths.get(path)));
+      return this;
+   }
+
+   public <K, V> PersistenceUnitProperties setAll(Map<K, V> properties) {
+      ensureUnlocked();
+      this.properties.putAll(properties);
+      return this;
+   }
+
+   public PersistenceUnitProperties set(String key, String value) {
+      ensureUnlocked();
+      properties.setProperty(key, value);
+      return this;
+   }
+
+   public Properties getProperties() {
+      return properties;
+   }
+
+   protected PersistenceUnitProperties lock() {
+      locked = true;
+      return this;
+   }
+
+   private void ensureUnlocked() {
+      if (locked) {
+         throw new IllegalStateException("Can not set properties after initialization");
+      }
+   }
+}


### PR DESCRIPTION
La idea de este PR es permitir overridear la conexión con la base de datos programáticamente. Esto permitiría setear esos parámetros después de la compilación, por ejemplo, usando variables de entorno o cargando un archivo `*.properties`:

```java
PersistenceUnitProperties props = PersistenceUnitProperties.INSTANCE;

props.loadFile("src/main/resources/application.properties");

props.setAll(System.getenv());

props.set("hibernate.connection.driver_class", "org.hsqldb.jdbc.JDBCDriver")
     .set("hibernate.connection.url", "jdbc:hsqldb:mem:app-db")
     .set("hibernate.connection.username", "sa")
     .set("hibernate.connection.password", "");
```


Para evitar inconsistencias hice que arroje una excepción en caso de que el `EntityManagerFactory` ya haya sido inicializado:

```
Exception in thread "main" java.lang.IllegalStateException: Can not set properties after initialization
```